### PR TITLE
README: Fix printing the abbreviation in bold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Reba
 
-Reba is a <b>ren</b>derer <b>ba</b>se that builds a set of high quality open-source C++ libraries using Docker, so that you can hit the ground running when starting your graphics project.
+Reba is a **re**nderer **ba**se that builds a set of high quality open-source C++ libraries using Docker, so that you can hit the ground running when starting your graphics project.
 
 <!--div style="
     width:300px;


### PR DESCRIPTION
The "n" is not part of the abbreviation. Also use Markdown instead of HTML.
